### PR TITLE
Remove index.browser.js, which bundled a separate version of Redux inside

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "jam": {
     "main": "./dist/index.browser.js"
   },
-  "browser": {
-    "dist/index.js": "./dist/index.browser.js"
-  },
   "scripts": {
     "build": "webpack || echo not ok",
     "test": "jest",
@@ -44,7 +41,6 @@
   "devDependencies": {
     "@types/jest": "^21.1.1",
     "@types/node": "^8.0.31",
-    "browserify": "^14.4.0",
     "delete-empty": "^1.0.1",
     "dts-bundle": "^0.7.3",
     "jest": "^20.0.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 var nodeExternals = require('webpack-node-externals');
 var webpack = require('webpack');
-var browserify = require('browserify');
 var path = require('path');
 var fs = require('fs');
 var os = require('os');
@@ -47,9 +46,6 @@ var percentage_handler = function handler(percentage, msg) {
     /* Build Started */
     outputCleanup(libPath());
     console.log('Build started... Good luck!');
-  } else if ( 1.0 === percentage ) {
-    // TODO: No Error detection. :(
-    create_browser_version(webpack_opts.output.filename);
   }
 }
 
@@ -96,23 +92,6 @@ var webpack_opts = {
     }),
     new webpack.ProgressPlugin(percentage_handler)
   ],
-}
-
-var create_browser_version = function (inputJs) {
-  let outputName = inputJs.replace(/\.[^/.]+$/, '');
-  outputName = `${outputName}.browser.js`;
-  console.log('Creating browser version ...');
-
-  let b = browserify(inputJs, {
-    standalone: LIB_NAME,
-  });
-
-  b.bundle(function(err, src) {
-    if ( err != null ) {
-      console.error('Browserify error:');
-      console.error(err);
-    }
-  }).pipe(fs.createWriteStream(outputName));
 }
 
 module.exports = webpack_opts;


### PR DESCRIPTION
index.browser.js bundled a separate version of Redux, causing some hard-to-debug issues (such as why redux kept printing "You are using minified code outside of NODE_ENV === production").

Modern bundlers like webpack should be able to handle the normal `dist/index.js` file fine now, resolving imports as necessary without explicit browserifying in this package. However, having the `"browser": "dist/index.js"` alias made it _impossible_ to import the `dist/index.js` file, as it would always import `index.browser.js` instead.

This change removes the `index.browser.js` build and the alias for it.

Let me know if there's a reason to keep the `index.browser.js` file around; if so, we might be able to find an alternative solution.